### PR TITLE
Build a tenant tag from account type and account

### DIFF
--- a/src/main/java/com/rackspace/salus/event/ingest/config/EventIngestProperties.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/config/EventIngestProperties.java
@@ -26,4 +26,10 @@ import org.springframework.stereotype.Component;
 public class EventIngestProperties {
   String influxDbDatabaseOverride;
   String influxDbRetentionPolicyOverride;
+
+  /**
+   * The delimiter to use when constructing a qualified account value.
+   */
+  String qualifiedAccountDelimiter = ":";
+
 }

--- a/src/main/java/com/rackspace/salus/event/ingest/services/InfluxConnectionPool.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/InfluxConnectionPool.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.ingest.services;
+
+import com.rackspace.salus.event.discovery.EngineInstance;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InfluxConnectionPool implements Closeable {
+  private final ConcurrentHashMap<EngineInstance, InfluxDB> influxConnections =
+      new ConcurrentHashMap<>();
+
+  public InfluxDB getConnection(EngineInstance engineInstance) {
+    return influxConnections.computeIfAbsent(
+        engineInstance,
+        key ->
+            InfluxDBFactory.connect(
+                String.format("http://%s:%d", key.getHost(), key.getPort())
+            )
+    );
+  }
+
+  @Override
+  public void close() throws IOException {
+    influxConnections.forEachValue(1, InfluxDB::close);
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
@@ -69,7 +69,7 @@ public class IngestService implements Closeable {
   public void consumeMetric(ExternalMetric metric) {
     log.trace("Ingesting metric={}", metric);
 
-    final String tenant = String.join(":",
+    final String qualifiedAccount = String.join(":",
         metric.getAccountType().toString(),
         metric.getAccount()
         );
@@ -78,7 +78,7 @@ public class IngestService implements Closeable {
         .pickRecipient(metric.getAccount(), metric.getDevice(), metric.getCollectionName());
 
     log.debug("Sending measurement={} for tenant={} to engine={}",
-        metric.getCollectionName(), tenant, engineInstance);
+        metric.getCollectionName(), qualifiedAccount, engineInstance);
 
     final InfluxDB kapacitorWriter = influxConnectionPool.getConnection(engineInstance);
 
@@ -89,7 +89,7 @@ public class IngestService implements Closeable {
     metric.getSystemMetadata().forEach(pointBuilder::tag);
     metric.getCollectionMetadata().forEach(pointBuilder::tag);
     metric.getDeviceMetadata().forEach(pointBuilder::tag);
-    pointBuilder.tag(Tags.TENANT, tenant);
+    pointBuilder.tag(Tags.QUALIFIED_ACCOUNT, qualifiedAccount);
     pointBuilder.tag(Tags.RESOURCE_ID, metric.getDevice());
     if (StringUtils.hasText(metric.getDeviceLabel())) {
       pointBuilder.tag(Tags.RESOURCE_LABEL, metric.getDeviceLabel());

--- a/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.event.ingest.services;
 
+import static com.rackspace.salus.telemetry.model.LabelNamespaces.MONITORING_SYSTEM_METADATA;
+
 import com.rackspace.monplat.protocol.ExternalMetric;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.event.common.InfluxScope;
@@ -23,6 +25,7 @@ import com.rackspace.salus.event.common.Tags;
 import com.rackspace.salus.event.discovery.EngineInstance;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
 import com.rackspace.salus.event.ingest.config.EventIngestProperties;
+import com.rackspace.salus.telemetry.model.LabelNamespaces;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
@@ -88,7 +91,12 @@ public class IngestService implements Closeable {
     final Builder pointBuilder = Point.measurement(metric.getCollectionName())
         .time(timestamp.toEpochMilli(), TimeUnit.MILLISECONDS);
 
-    metric.getSystemMetadata().forEach(pointBuilder::tag);
+    metric.getSystemMetadata()
+        .forEach((name, value) ->
+            pointBuilder.tag(
+                LabelNamespaces.applyNamespace(MONITORING_SYSTEM_METADATA, value),
+                value
+            ));
     metric.getCollectionMetadata().forEach(pointBuilder::tag);
     metric.getDeviceMetadata().forEach(pointBuilder::tag);
     pointBuilder.tag(Tags.QUALIFIED_ACCOUNT, qualifiedAccount);

--- a/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
@@ -69,9 +69,11 @@ public class IngestService implements Closeable {
   public void consumeMetric(ExternalMetric metric) {
     log.trace("Ingesting metric={}", metric);
 
-    final String qualifiedAccount = String.join(":",
-        metric.getAccountType().toString(),
-        metric.getAccount()
+    final String qualifiedAccount =
+        String.join(
+            eventIngestProperties.getQualifiedAccountDelimiter(),
+            metric.getAccountType().toString(),
+            metric.getAccount()
         );
 
     final EngineInstance engineInstance = eventEnginePicker

--- a/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
@@ -25,7 +25,7 @@ import org.influxdb.InfluxDBFactory;
 import org.springframework.stereotype.Service;
 
 @Service
-public class InfluxConnectionPool implements Closeable {
+public class KapacitorConnectionPool implements Closeable {
   private final ConcurrentHashMap<EngineInstance, InfluxDB> influxConnections =
       new ConcurrentHashMap<>();
 

--- a/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.ingest.services;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.monplat.protocol.AccountType;
+import com.rackspace.monplat.protocol.ExternalMetric;
+import com.rackspace.monplat.protocol.MonitoringSystem;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.event.common.InfluxScope;
+import com.rackspace.salus.event.common.Tags;
+import com.rackspace.salus.event.discovery.EngineInstance;
+import com.rackspace.salus.event.discovery.EventEnginePicker;
+import com.rackspace.salus.event.ingest.config.EventIngestProperties;
+import java.util.concurrent.TimeUnit;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Point;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class IngestServiceTest {
+
+  @Configuration
+  @Import({IngestService.class})
+  public static class TestConfig {
+    @Bean
+    public KafkaTopicProperties kafkaTopicProperties() {
+      return new KafkaTopicProperties();
+    }
+
+    @Bean
+    public EventIngestProperties eventIngestProperties() {
+      return new EventIngestProperties();
+    }
+  }
+
+  @MockBean
+  EventEnginePicker eventEnginePicker;
+
+  @MockBean
+  InfluxConnectionPool influxConnectionPool;
+
+  @Autowired
+  IngestService ingestService;
+
+  @Mock
+  InfluxDB influxDB;
+
+  @Test
+  public void consumeMetric() {
+    final ExternalMetric metric = ExternalMetric.newBuilder()
+        .setTimestamp("2018-03-27T13:15:06.497Z")
+        .setAccountType(AccountType.CORE)
+        .setAccount("123456")
+        .setMonitoringSystem(MonitoringSystem.SALUS)
+        .setDevice("r-1")
+        .setDeviceLabel("resourceLabel-1")
+        .setSystemMetadata(singletonMap("skey", "sval"))
+        .setDeviceMetadata(singletonMap("dkey", "dval"))
+        .setCollectionName("cpu")
+        .setCollectionMetadata(singletonMap("ckey", "cval"))
+        .setCollectionTarget("")
+        .setIvalues(singletonMap("ivalue", 5L))
+        .setFvalues(singletonMap("fvalue", 3.14))
+        .setSvalues(singletonMap("svalue", "testing"))
+        .setUnits(emptyMap())
+        .build();
+
+    when(eventEnginePicker.pickRecipient(any(), any(), any()))
+        .thenReturn(
+            new EngineInstance("host", 123, 3)
+        );
+
+    when(influxConnectionPool.getConnection(any()))
+        .thenReturn(influxDB);
+
+    ingestService.consumeMetric(metric);
+
+    verify(eventEnginePicker).pickRecipient(
+        eq("123456"),
+        eq("r-1"),
+        eq("cpu")
+    );
+
+    verify(influxConnectionPool).getConnection(eq(new EngineInstance("host", 123, 3)));
+
+    Point point = Point.measurement("cpu")
+        .time(1522156506497L, TimeUnit.MILLISECONDS)
+        .tag(Tags.TENANT, "CORE:123456")
+        .tag(Tags.MONITORING_SYSTEM, MonitoringSystem.SALUS.toString())
+        .tag(Tags.RESOURCE_ID, "r-1")
+        .tag(Tags.RESOURCE_LABEL, "resourceLabel-1")
+        .tag("skey", "sval")
+        .tag("dkey", "dval")
+        .tag("ckey", "cval")
+        .addField("ivalue", 5L)
+        .addField("fvalue", 3.14)
+        .addField("svalue", "testing")
+        .build();
+
+    verify(influxDB).write(
+        eq("123456"),
+        eq(InfluxScope.INGEST_RETENTION_POLICY),
+        eq(point)
+    );
+
+    verifyNoMoreInteractions(eventEnginePicker, influxConnectionPool, influxDB);
+  }
+}

--- a/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
@@ -117,7 +117,7 @@ public class IngestServiceTest {
 
     Point point = Point.measurement("cpu")
         .time(1522156506497L, TimeUnit.MILLISECONDS)
-        .tag(Tags.TENANT, "CORE:123456")
+        .tag(Tags.QUALIFIED_ACCOUNT, "CORE:123456")
         .tag(Tags.MONITORING_SYSTEM, MonitoringSystem.SALUS.toString())
         .tag(Tags.RESOURCE_ID, "r-1")
         .tag(Tags.RESOURCE_LABEL, "resourceLabel-1")


### PR DESCRIPTION
# Resolves

Discovered during https://jira.rax.io/browse/SALUS-262

# What

While testing https://github.com/racker/salus-event-engine-common/pull/2 I discovered that the routing of the account needed to qualify that with the account type like we have discussed for the metrics storage.

# How

Rather than derive an Influx database name from the `account` alone, qualify that by `accountType` and also use that as a newly declared tenant tag.

## How to test

The first and only unit test was added as part of this change.

# TODO

Not part of this PR, but the event engine management will need to be updated to convert an authentication tenant ID into an `accountType:account` style tenant.