### PR TITLE
Adding a dev config for testing kubernetes discovery

### DIFF
--- a/src/main/resources/application-dev-kube.yml
+++ b/src/main/resources/application-dev-kube.yml
@@ -1,0 +1,12 @@
+# This app config can be used to operate against a local Docker for Desktop kubernetes cluster
+logging:
+  level:
+    com.rackspace.salus.event: debug
+event:
+  discovery:
+    kubernetes-strategy:
+      api-url: https://localhost:6443
+      service-name: kapacitor
+    partitions: 2
+server:
+  port: 0

--- a/src/main/resources/application-dev-kube.yml
+++ b/src/main/resources/application-dev-kube.yml
@@ -7,6 +7,5 @@ event:
     kubernetes-strategy:
       api-url: https://localhost:6443
       service-name: kapacitor
-    partitions: 2
 server:
   port: 0

--- a/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
@@ -33,6 +33,7 @@ import com.rackspace.salus.event.common.InfluxScope;
 import com.rackspace.salus.event.common.Tags;
 import com.rackspace.salus.event.discovery.EngineInstance;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
+import com.rackspace.salus.event.discovery.NoPartitionsAvailableException;
 import com.rackspace.salus.event.ingest.config.EventIngestProperties;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +81,7 @@ public class IngestServiceTest {
   InfluxDB influxDB;
 
   @Test
-  public void consumeMetric() {
+  public void consumeMetric() throws NoPartitionsAvailableException {
     final ExternalMetric metric = ExternalMetric.newBuilder()
         .setTimestamp("2018-03-27T13:15:06.497Z")
         .setAccountType(AccountType.CORE)


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-191

# What

Adds an app config to use for manually verifying the logic added in https://github.com/racker/salus-event-engine-common/pull/3 against a local kubernetes cluster running in Docker for Desktop.