### PR TITLE
Use qualified account ID for kapacitor db field

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
 ## How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,12 +1,12 @@
 
 logging:
   level:
-    com.rackspace.salus.event.ingest: debug
+    com.rackspace.salus.event.ingest: trace
 event:
   discovery:
     port-strategy:
       host: localhost
       starting-port: 9192
-    partitions: 2
+      partitions: 2
 server:
   port: 0


### PR DESCRIPTION
# What

The tenant ID was getting qualified with the account in portions of the metrics building, but wasn't being used for the final kapacitor "db" designation.

This also fixes the dev profile config to declare `partitions` of `port-strategy` in the new location.