### PR TITLE
Exclude conflicting servlet-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
       <groupId>com.rackspace.monplat</groupId>
       <artifactId>umb-protocol</artifactId>
       <version>0.1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+          <groupId>org.mortbay.jetty</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>


### PR DESCRIPTION
The avro-rpc dependency in umb-protocol is introducing a conflicting instance of the servlet-api. When this app is containerized, it causes this startup failure:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

An attempt was made to call the method javax.servlet.ServletContext.getVirtualServerName()Ljava/lang/String; but it does not exist. Its class, javax.servlet.ServletContext, is available from the following locations:

    jar:file:/app/libs/servlet-api-2.5-20081211.jar!/javax/servlet/ServletContext.class
    jar:file:/app/libs/tomcat-embed-core-9.0.14.jar!/javax/servlet/ServletContext.class

It was loaded from the following location:

    file:/app/libs/servlet-api-2.5-20081211.jar


Action:

Correct the classpath of your application so that it contains a single, compatible version of javax.servlet.ServletContext
```

# How

Exclude the unused dependency from the transitive dependencies of umb-protocol.

Same change as https://github.com/racker/salus-telemetry-presence-monitor/pull/28