### PR TITLE
Qualify kafka consumer group by cluster environment

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,11 @@
+salus:
+  environment: local
 spring:
   kafka:
     consumer:
       value-deserializer: com.rackspace.monplat.protocol.ExternalMetricDeserializer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      group-id: ${spring.application.name}
+      group-id: ${spring.application.name}-${salus.environment}
       auto-offset-reset: latest
   application:
     name: salus-event-engine-ingest


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-544

# What

Since there's not yet a UMB instance per cluster/environment (dev, staging, prod), then we need to differentiate our kafka consumer group declarations to avoid application instances from multiple clusters all joining the same consumer group.

# How

Derive consumer group property in a way that can be done consistently across our apps.