### PR TITLE
Log metrics/points sent to kapacitor at trace level

### DIFF
--- a/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/IngestService.java
@@ -90,9 +90,6 @@ public class IngestService implements Closeable {
       return;
     }
 
-    log.debug("Sending measurement={} for tenant={} resourceId={} to engine={}",
-        metric.getCollectionName(), qualifiedAccount, resourceId, engineInstance);
-
     // Kapacitor provides a write endpoint that is compatible with InfluxDB, which is why
     // a native InfluxDB client is used here.
     final InfluxDB kapacitorWriter = kapacitorConnectionPool.getConnection(engineInstance);
@@ -120,10 +117,17 @@ public class IngestService implements Closeable {
     metric.getFvalues().forEach(pointBuilder::addField);
     metric.getSvalues().forEach(pointBuilder::addField);
 
+
+    final Point influxPoint = pointBuilder.build();
+
+    log.trace("Sending influxPoint={} for tenant={} resourceId={} to engine={}",
+        influxPoint, qualifiedAccount, resourceId, engineInstance);
+
     kapacitorWriter.write(
         deriveIngestDatabase(qualifiedAccount),
         deriveRetentionPolicy(),
-        pointBuilder.build());
+        influxPoint
+    );
   }
 
   private String deriveRetentionPolicy() {


### PR DESCRIPTION
# What

Previously we were logging at debug level every time a measurement was sent to kapacitor. I had devops increase the log level filter to info in our deployment; however, now we can debug the kube kapacitor discovery results which are logged at debug level.

# How

Lower log level of per-measurement logs to trace and also include the populated Influx `Point` since that could help for debugging kapacitor tasks.

## How to test

Existing unit tests still work