### PR TITLE
Defaulted kafka's missing-topics-fatal to false in our local config

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,3 +10,8 @@ salus.event:
       partitions: 1
 server:
   port: 0
+spring:
+  kafka:
+    listener:
+      # this will allow for to start consumer of a particular topic before the producer
+      missing-topics-fatal: false

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,5 +13,5 @@ server:
 spring:
   kafka:
     listener:
-      # this will allow for to start consumer of a particular topic before the producer
+      # this will allow for us to start consumer of a particular topic before the producer
       missing-topics-fatal: false


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-738

# What

With the Spring Boot 2.2.4 upgrade the default must have changed for `spring.kafka.listener.missing-topics-fatal` from false to true or it's a new condition spring kafka checks. In any case, when starting one of our kafka-consuming apps locally it was failing to start since I had a fresh kafka container without the topic it wanted. It's a good property and default to have in production, but annoying locally.