### PR TITLE
Updated ingest service to allow configuring multiple topics

### DIFF
--- a/src/main/java/com/rackspace/salus/event/ingest/config/EventIngestProperties.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/config/EventIngestProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.event.ingest.config;
 
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -32,4 +33,8 @@ public class EventIngestProperties {
    */
   String qualifiedAccountDelimiter = ":";
 
+  /**
+   * Topics to be ingested that contain com.rackspace.monplat.protocol.ExternalMetric messages encoded as JSON.
+   */
+  List<String> topics = List.of("telemetry.metrics.json");
 }

--- a/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceKafkaTest.java
+++ b/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceKafkaTest.java
@@ -59,7 +59,7 @@ import org.springframework.test.context.junit4.SpringRunner;
         MeterRegistryTestConfig.class
     },
     properties = {
-        "salus.kafka.topics.metrics="+ IngestServiceKafkaTest.TOPIC,
+        "salus.event.ingest.topics="+ IngestServiceKafkaTest.TOPIC,
         // override app default so that we can produce before consumer is ready
         "spring.kafka.consumer.auto-offset-reset=earliest",
         "logging.level.com.rackspace.salus.common.messaging.KafkaErrorConfig=debug"

--- a/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.rackspace.monplat.protocol.ExternalMetric;
-import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.event.discovery.EngineInstance;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
 import com.rackspace.salus.event.discovery.NoPartitionsAvailableException;
@@ -53,11 +52,6 @@ public class IngestServiceTest {
   @Configuration
   @Import({IngestService.class, MeterRegistryTestConfig.class})
   public static class TestConfig {
-    @Bean
-    public KafkaTopicProperties kafkaTopicProperties() {
-      return new KafkaTopicProperties();
-    }
-
     @Bean
     public EventIngestProperties eventIngestProperties() {
       return new EventIngestProperties();


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-833

# What

For Salus metrics ingest we only had a need for a single topic to be given to the Spring Kafka annotation; however, that original implementation had forgotten there would be non-Salus metrics eventually going through the engine.

# How

Change from a single topic string to a list, which was already supported by `@KafkaListener`.

## How to test

Updated property name in embedded kafka unit test.