### PR TITLE
enable batching on kapacitor writes to improve performance

### DIFF
--- a/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
@@ -20,6 +20,7 @@ import com.rackspace.salus.event.discovery.EngineInstance;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
+import org.influxdb.BatchOptions;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.springframework.stereotype.Service;
@@ -32,10 +33,12 @@ public class KapacitorConnectionPool implements Closeable {
   public InfluxDB getConnection(EngineInstance engineInstance) {
     return influxConnections.computeIfAbsent(
         engineInstance,
-        key ->
-            InfluxDBFactory.connect(
-                String.format("http://%s:%d", key.getHost(), key.getPort())
-            )
+        key -> {
+            InfluxDB influxDB = InfluxDBFactory.connect(
+                String.format("http://%s:%d", key.getHost(), key.getPort()));
+            influxDB.enableBatch(BatchOptions.DEFAULTS);
+            return influxDB;
+        }
     );
   }
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-853

# What

The documentation seems to suggest that we should be enabling batching on the ingestor writes:
https://github.com/influxdata/influxdb-java/blob/master/MANUAL.md#basic-usage

This is a preliminary PR to see if it helps the problem, with consumer lag on the ingestors.  If it does improve performance, then we need to decide if we need to improve the error handling, as suggested further down in the doc.

## How to test

all tests still pass
