### PR TITLE
Pinned cloudbuild to maven:3.6-jdk-11

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -51,8 +51,8 @@ steps:
       path: /root
 
   - id: DEPLOY
-    name: 'gcr.io/cloud-builders/mvn'
-    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    name: 'maven:3.6-jdk-11'
+    args: ['mvn', '-B', 'deploy', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,8 +28,8 @@ steps:
       path: /root
 
   - id: VERIFY
-    name: 'gcr.io/cloud-builders/mvn'
-    args: ['-B', 'verify', '-s', '.mvn/settings.xml']
+    name: 'maven:3.6-jdk-11'
+    args: ['mvn', '-B', 'verify', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root


### PR DESCRIPTION
# What

Our applications that use `@EmbeddedKafka` in unit tests are failing in GCB with a weird error during embedded zookeeper startup:

```
java.lang.IllegalArgumentException: Unable to canonicalize address 127.0.0.1/<unresolved>:46483 because it's not resolvable
```

The GCR image was using Java 14 and some unknown Maven version, so pinning both aspects to specific versions will help keep our builds robust anyway.