### PR TITLE
Adam/kapacitor connection failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
+  ~
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -30,6 +31,10 @@
   <artifactId>salus-event-engine-ingest</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <description>Ingest metrics into the Event Engine</description>
+
+  <properties>
+    <powermock.version>2.0.2</powermock.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -91,6 +96,18 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>1.7.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,13 @@
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty</artifactId>
       <version>3.10.8</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-client-java</artifactId>
       <version>3.10.8</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,6 @@
   <version>0.0.1-SNAPSHOT</version>
   <description>Ingest metrics into the Event Engine</description>
 
-  <properties>
-    <powermock.version>2.0.2</powermock.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -99,15 +95,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>1.7.4</version>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
+      <version>3.10.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>3.10.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.7</version>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.rackspace.salus.event.ingest.services;
@@ -20,13 +21,11 @@ import com.rackspace.salus.event.discovery.EngineInstance;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.influxdb.BatchOptions;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
-import org.influxdb.dto.Point;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -50,10 +49,6 @@ public class KapacitorConnectionPool implements Closeable {
             influxDB.enableBatch(BatchOptions.DEFAULTS.exceptionHandler((points, throwable) -> {
               batchIngestFailure.increment();
               log.error("Kafka Ingestion error with Batch: {}", points, throwable);
-              /*for(Point point : points) {
-                // Not sure I like this because its going to cause a slew of errors
-                log.error("Kafka Ingestion error with Point: " + point.lineProtocol(), throwable);
-              }*/
             }));
             return influxDB;
         }

--- a/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
+++ b/src/main/java/com/rackspace/salus/event/ingest/services/KapacitorConnectionPool.java
@@ -37,7 +37,7 @@ public class KapacitorConnectionPool implements Closeable {
   private final Counter batchIngestFailure;
 
   public KapacitorConnectionPool(MeterRegistry meterRegistry) {
-    this.batchIngestFailure = meterRegistry.counter("errors","operation", "batchFailure");
+    this.batchIngestFailure = meterRegistry.counter("errors","operation", "batchIngestFailure");
   }
 
   public InfluxDB getConnection(EngineInstance engineInstance) {

--- a/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceFailureTest.java
+++ b/src/test/java/com/rackspace/salus/event/ingest/services/IngestServiceFailureTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.rackspace.salus.event.ingest.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.rackspace.salus.event.discovery.EngineInstance;
+import com.rackspace.salus.event.discovery.EventEnginePicker;
+import com.rackspace.salus.event.ingest.config.EventIngestProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureMockRestServiceServer;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+@RunWith(SpringRunner.class)
+@RestClientTest(KapacitorConnectionPool.class)
+@Import({IngestService.class, MeterRegistryTestConfig.class, KapacitorConnectionPool.class})
+public class IngestServiceFailureTest {
+  String baseURI = "";
+  @Configuration
+  @Import({IngestService.class, MeterRegistryTestConfig.class})
+  public static class TestConfig {
+    @Bean
+    public EventIngestProperties eventIngestProperties() {
+      return new EventIngestProperties();
+    }
+
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder() {
+      return new RestTemplateBuilder()
+          .rootUri("");
+    }
+  }
+
+  @Autowired
+  private MockRestServiceServer mockServer;
+
+  @Autowired
+  KapacitorConnectionPool pool;
+
+  @Autowired
+  IngestService ingestService;
+
+  @MockBean
+  EventEnginePicker eventEnginePicker;
+
+  @Test
+  public void testGetPolicyMonitor_doesntExist() {
+    mockServer.expect(requestTo(baseURI+"/kapacitor/v1/write"))
+        .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    //probably going to need to figure out how to mock out the original connection to the server too.
+    EngineInstance eventEngine = eventEnginePicker.pickAll().stream().findFirst().get();
+    pool.getConnection(eventEngine);
+
+    //assertThat(result, nullValue());
+  }
+
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-867

# What

Make sure we have error handling in kapacitor ingestion in case we can't write a batch to kapacitor and that it gets logged and noted for grafana.

# How

We register an anonymous function when we enable batching that will handle any errors that we see from kapacitor. 

## How to test

Unit tests have been updated. 

# Why

An anonymous function gets us access to `MeterRegistry` without having to add that support to a new class. 
